### PR TITLE
Update PostgreSQL tmpfs mount for Postgres 18+ compatibility

### DIFF
--- a/src/test/pg-container.ts
+++ b/src/test/pg-container.ts
@@ -118,7 +118,7 @@ export const createPostgresContainer = async () => {
       "POSTGRES_MAX_WAL_SENDERS=0",
       // Use tmpfs for faster I/O
       "--tmpfs",
-      "/var/lib/postgresql/data:rw,noexec,nosuid,size=512m",
+      "/var/lib/postgresql:rw,noexec,nosuid,size=512m",
       "-p",
       `${port}:5432`,
       "postgres:alpine",


### PR DESCRIPTION
The E2E tests were failing to start the PostgreSQL container, resulting in a hang.
This is due to a breaking change in PostgreSQL 18.x container images regarding how data directories are handled.
 Specifically, `postgres:alpine` (which now defaults to PostgreSQL 18.x) expects the data mount to be at `/var/lib/postgresql` rather than `/var/lib/postgresql/data`.

**Relevant Issues/References:**
- PostgreSQL Docker image issue tracking this change:
  - [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)
  - [docker-library/postgres#37](https://github.com/docker-library/postgres/issues/37)
