### PR TITLE
Fix dateTime filtering operators producing incorrect results

### DIFF
--- a/src/client/parser/processors/aggregate-processor.ts
+++ b/src/client/parser/processors/aggregate-processor.ts
@@ -454,14 +454,30 @@ export class AggregateProcessor {
   }
 
   private cleanResult(result: ParseResult): ParseResult {
-    return JSON.parse(
-      JSON.stringify(result, (k, v) => {
-        if (v === undefined || v === null) return v;
-        if (Array.isArray(v) && v.length === 0) return;
-        if (typeof v === "object" && Object.keys(v).length === 0) return;
-        return v;
-      }),
-    );
+    const clean = (v: any): any => {
+      if (v === undefined || v === null) return v;
+      if (v instanceof Date) return v;
+      if (typeof Buffer !== "undefined" && v instanceof Buffer) return v;
+      if (Array.isArray(v)) {
+        const cleaned = v.map(clean).filter((x) => x !== undefined);
+        return cleaned.length === 0 ? undefined : cleaned;
+      }
+      if (typeof v === "object") {
+        if (v.constructor === Object) {
+          const out: Record<string, any> = {};
+          for (const [k, val] of Object.entries(v)) {
+            const cleaned = clean(val);
+            if (cleaned !== undefined) out[k] = cleaned;
+          }
+          return Object.keys(out).length === 0 ? undefined : out;
+        }
+        if (typeof v.toJSON === "function") {
+          return v.toJSON();
+        }
+      }
+      return v;
+    };
+    return (clean(result) || {}) as ParseResult;
   }
 
   static parse(

--- a/src/client/parser/processors/aggregate-processor.ts
+++ b/src/client/parser/processors/aggregate-processor.ts
@@ -4,6 +4,7 @@ import { JoinHandler } from "../handlers/join-handler";
 import { JsonQueryHandler } from "../handlers/json-handler";
 import { AggregateOptions, ParseResult, QueryClient } from "../types";
 import { WhereProcessor } from "./where-processor";
+import { cleanResult } from "./util";
 
 export class AggregateProcessor {
   private context: ParserContext;
@@ -160,7 +161,7 @@ export class AggregateProcessor {
       skip,
     };
 
-    return this.cleanResult(result);
+    return cleanResult(result);
   }
 
   private processAggregateOperations(
@@ -451,33 +452,6 @@ export class AggregateProcessor {
       le: "<=",
     };
     return operators[operator] || "=";
-  }
-
-  private cleanResult(result: ParseResult): ParseResult {
-    const clean = (v: any): any => {
-      if (v === undefined || v === null) return v;
-      if (v instanceof Date) return v;
-      if (typeof Buffer !== "undefined" && v instanceof Buffer) return v;
-      if (Array.isArray(v)) {
-        const cleaned = v.map(clean).filter((x) => x !== undefined);
-        return cleaned.length === 0 ? undefined : cleaned;
-      }
-      if (typeof v === "object") {
-        if (v.constructor === Object) {
-          const out: Record<string, any> = {};
-          for (const [k, val] of Object.entries(v)) {
-            const cleaned = clean(val);
-            if (cleaned !== undefined) out[k] = cleaned;
-          }
-          return Object.keys(out).length === 0 ? undefined : out;
-        }
-        if (typeof v.toJSON === "function") {
-          return v.toJSON();
-        }
-      }
-      return v;
-    };
-    return (clean(result) || {}) as ParseResult;
   }
 
   static parse(

--- a/src/client/parser/processors/query-processor.ts
+++ b/src/client/parser/processors/query-processor.ts
@@ -9,6 +9,7 @@ import { ParseResult } from "../types";
 import { OrderByProcessor } from "./order-processor";
 import { SelectProcessor } from "./select-processor";
 import { WhereProcessor } from "./where-processor";
+import { cleanResult } from "./util";
 
 export class QueryProcessor {
   private selectProcessor: SelectProcessor;
@@ -90,34 +91,7 @@ export class QueryProcessor {
     };
 
     // Clean up undefined/empty values
-    return this.cleanResult(result);
-  }
-
-  private cleanResult(result: ParseResult): ParseResult {
-    const clean = (v: any): any => {
-      if (v === undefined || v === null) return v;
-      if (v instanceof Date) return v;
-      if (typeof Buffer !== "undefined" && v instanceof Buffer) return v;
-      if (Array.isArray(v)) {
-        const cleaned = v.map(clean).filter((x) => x !== undefined);
-        return cleaned.length === 0 ? undefined : cleaned;
-      }
-      if (typeof v === "object") {
-        if (v.constructor === Object) {
-          const out: Record<string, any> = {};
-          for (const [k, val] of Object.entries(v)) {
-            const cleaned = clean(val);
-            if (cleaned !== undefined) out[k] = cleaned;
-          }
-          return Object.keys(out).length === 0 ? undefined : out;
-        }
-        if (typeof v.toJSON === "function") {
-          return v.toJSON();
-        }
-      }
-      return v;
-    };
-    return (clean(result) || {}) as ParseResult;
+    return cleanResult(result);
   }
 
   static parse(

--- a/src/client/parser/processors/query-processor.ts
+++ b/src/client/parser/processors/query-processor.ts
@@ -94,14 +94,30 @@ export class QueryProcessor {
   }
 
   private cleanResult(result: ParseResult): ParseResult {
-    return JSON.parse(
-      JSON.stringify(result, (k, v) => {
-        if (v === undefined || v === null) return v;
-        if (Array.isArray(v) && v.length === 0) return;
-        if (typeof v === "object" && Object.keys(v).length === 0) return;
-        return v;
-      }),
-    );
+    const clean = (v: any): any => {
+      if (v === undefined || v === null) return v;
+      if (v instanceof Date) return v;
+      if (typeof Buffer !== "undefined" && v instanceof Buffer) return v;
+      if (Array.isArray(v)) {
+        const cleaned = v.map(clean).filter((x) => x !== undefined);
+        return cleaned.length === 0 ? undefined : cleaned;
+      }
+      if (typeof v === "object") {
+        if (v.constructor === Object) {
+          const out: Record<string, any> = {};
+          for (const [k, val] of Object.entries(v)) {
+            const cleaned = clean(val);
+            if (cleaned !== undefined) out[k] = cleaned;
+          }
+          return Object.keys(out).length === 0 ? undefined : out;
+        }
+        if (typeof v.toJSON === "function") {
+          return v.toJSON();
+        }
+      }
+      return v;
+    };
+    return (clean(result) || {}) as ParseResult;
   }
 
   static parse(

--- a/src/client/parser/processors/util.ts
+++ b/src/client/parser/processors/util.ts
@@ -1,0 +1,28 @@
+import { type ParseResult } from "../types";
+
+export const cleanResult = (result: ParseResult): ParseResult => {
+  const clean = (v: any): any => {
+    if (v === undefined || v === null) return v;
+    if (v instanceof Date) return v;
+    if (typeof Buffer !== "undefined" && Buffer.isBuffer(v)) return v;
+    if (Array.isArray(v)) {
+      const cleaned = v.map(clean).filter((x) => x !== undefined);
+      return cleaned.length === 0 ? undefined : cleaned;
+    }
+    if (typeof v === "object") {
+      if (v.constructor === Object) {
+        const out: Record<string, any> = {};
+        for (const [k, val] of Object.entries(v)) {
+          const cleaned = clean(val);
+          if (cleaned !== undefined) out[k] = cleaned;
+        }
+        return Object.keys(out).length === 0 ? undefined : out;
+      }
+      if (typeof v.toJSON === "function") {
+        return v.toJSON();
+      }
+    }
+    return v;
+  };
+  return (clean(result) || {}) as ParseResult;
+};


### PR DESCRIPTION
- DateTime comparison operators were not working correctly when filtering by `DateTime` fields
- Root cause: `cleanResult` used `JSON.parse(JSON.stringify(...))` which serialized `Date` objects to ISO strings, causing TypeORM to receive strings instead of `Date` instances as query parameters
- Fix: replaced the JSON round-trip with a manual recursive `clean` function that correctly handles all supported field types — preserving `Date` and `Buffer` instances for the pg driver, and calling `toJSON()` on custom types like `BigDecimal` to avoid double-serialization

