### PR TITLE
Fix JSON Path Filtering Producing Incorrect Results

### DIFF
--- a/src/client/parser/context.ts
+++ b/src/client/parser/context.ts
@@ -15,10 +15,13 @@ export function acceptWhereCauses(
 
 export function findJsonType(value: any): keyof typeof JSON_CAST_TYPES {
   if (Array.isArray(value)) value = value[0];
+  if (value === null || value === undefined) return "String";
   if (typeof value === "number") return "Int";
   if (typeof value === "boolean") return "Boolean";
-  if (/^(-)?(\d+)(\.\d+)?$/.test(value)) return "Decimal";
-  if (/^(\d{4})-(\d{2})-(\d{2}).*$/.test(value)) return "Date";
+  if (typeof value === "string") {
+    if (/^(-)?(\d+)(\.\d+)?$/.test(value)) return "Decimal";
+    if (/^(\d{4})-(\d{2})-(\d{2}).*$/.test(value)) return "Date";
+  }
   return "String";
 }
 

--- a/src/client/parser/handlers/json-handler.ts
+++ b/src/client/parser/handlers/json-handler.ts
@@ -104,9 +104,11 @@ export class JsonQueryHandler {
 
     if (type === "decimal") {
       condition = condition.replace(/@/g, "@.double()");
+      condition = condition.replace(/\$(\w+)/g, "$$$1.double()");
     }
-    if (type === "datetime") {
+    if (type === "datetime" || type === "Date" || type === "timestamp") {
       condition = condition.replace(/@/g, "@.datetime()");
+      condition = condition.replace(/\$(\w+)/g, "$$$1.datetime()");
     }
 
     if (op.startsWith("not")) condition = `!(${condition})`;

--- a/src/client/parser/handlers/json-handler.ts
+++ b/src/client/parser/handlers/json-handler.ts
@@ -103,10 +103,10 @@ export class JsonQueryHandler {
     }
 
     if (type === "decimal") {
-      condition = condition.replace("@", "@.double()");
+      condition = condition.replace(/@/g, "@.double()");
     }
     if (type === "datetime") {
-      condition = condition.replace("@", "@.datetime()");
+      condition = condition.replace(/@/g, "@.datetime()");
     }
 
     if (op.startsWith("not")) condition = `!(${condition})`;

--- a/src/test/json.test.ts
+++ b/src/test/json.test.ts
@@ -164,3 +164,167 @@ describe("json tests", async () => {
     expect(Math.max(...vals)).toBe(max);
   });
 });
+
+describe("json filter tests", async () => {
+  const client = await getTestClient();
+
+  describe("Decimal comparisons in JSON", () => {
+    const low = "10.00";
+    const exact = "50.00";
+    const high = "90.00";
+
+    beforeEach(async () => {
+      await client.contact.create({
+        data: {
+          firstName: "Decimal",
+          lastName: "Test",
+          attrs: Promise.resolve({ salary: exact }),
+        },
+        select: { id: true },
+      });
+    });
+
+    const findBySalary = (salary: any) =>
+      client.contact.find({
+        where: { attrs: { path: "salary", ...salary, type: "Decimal" } },
+        select: { id: true },
+      });
+
+    it("eq", async () => {
+      expect(await findBySalary({ eq: exact })).toHaveLength(1);
+      expect(await findBySalary({ eq: high })).toHaveLength(0);
+    });
+
+    it("ne", async () => {
+      expect(await findBySalary({ ne: high })).toHaveLength(1);
+      expect(await findBySalary({ ne: exact })).toHaveLength(0);
+    });
+
+    it("gt", async () => {
+      expect(await findBySalary({ gt: low })).toHaveLength(1);
+      expect(await findBySalary({ gt: high })).toHaveLength(0);
+      expect(await findBySalary({ gt: exact })).toHaveLength(0);
+    });
+
+    it("ge", async () => {
+      expect(await findBySalary({ ge: exact })).toHaveLength(1);
+      expect(await findBySalary({ ge: low })).toHaveLength(1);
+      expect(await findBySalary({ ge: high })).toHaveLength(0);
+    });
+
+    it("lt", async () => {
+      expect(await findBySalary({ lt: high })).toHaveLength(1);
+      expect(await findBySalary({ lt: low })).toHaveLength(0);
+      expect(await findBySalary({ lt: exact })).toHaveLength(0);
+    });
+
+    it("le", async () => {
+      expect(await findBySalary({ le: exact })).toHaveLength(1);
+      expect(await findBySalary({ le: high })).toHaveLength(1);
+      expect(await findBySalary({ le: low })).toHaveLength(0);
+    });
+
+    it("in", async () => {
+      expect(await findBySalary({ in: [low, exact, high] })).toHaveLength(1);
+      expect(await findBySalary({ in: [low, high] })).toHaveLength(0);
+    });
+
+    it("notIn", async () => {
+      expect(await findBySalary({ notIn: [low, high] })).toHaveLength(1);
+      expect(await findBySalary({ notIn: [low, exact, high] })).toHaveLength(0);
+    });
+
+    it("between", async () => {
+      expect(await findBySalary({ between: [low, high] })).toHaveLength(1);
+      expect(await findBySalary({ between: [exact, exact] })).toHaveLength(1);
+      expect(await findBySalary({ between: [high, high] })).toHaveLength(0);
+    });
+
+    it("notBetween", async () => {
+      expect(await findBySalary({ notBetween: [high, high] })).toHaveLength(1);
+      expect(await findBySalary({ notBetween: [low, high] })).toHaveLength(0);
+    });
+  });
+
+  describe("Date comparisons in JSON", () => {
+    const past = "2020-01-01";
+    const exact = "2020-01-02";
+    const future = "2020-01-03";
+
+    beforeEach(async () => {
+      await client.contact.create({
+        data: {
+          firstName: "Date",
+          lastName: "Test",
+          attrs: Promise.resolve({ createdAt: exact }),
+        },
+        select: { id: true },
+      });
+    });
+
+    const findByDate = (createdAt: object) =>
+      client.contact.find({
+        where: { attrs: { path: "createdAt", ...createdAt, type: "Date" } },
+        select: { id: true },
+      });
+
+    it("eq", async () => {
+      expect(await findByDate({ eq: exact })).toHaveLength(1);
+      expect(await findByDate({ eq: future })).toHaveLength(0);
+    });
+
+    it("ne", async () => {
+      expect(await findByDate({ ne: future })).toHaveLength(1);
+      expect(await findByDate({ ne: exact })).toHaveLength(0);
+    });
+
+    it("gt", async () => {
+      expect(await findByDate({ gt: past })).toHaveLength(1);
+      expect(await findByDate({ gt: future })).toHaveLength(0);
+      expect(await findByDate({ gt: exact })).toHaveLength(0);
+    });
+
+    it("ge", async () => {
+      expect(await findByDate({ ge: exact })).toHaveLength(1);
+      expect(await findByDate({ ge: past })).toHaveLength(1);
+      expect(await findByDate({ ge: future })).toHaveLength(0);
+    });
+
+    it("lt", async () => {
+      expect(await findByDate({ lt: future })).toHaveLength(1);
+      expect(await findByDate({ lt: past })).toHaveLength(0);
+      expect(await findByDate({ lt: exact })).toHaveLength(0);
+    });
+
+    it("le", async () => {
+      expect(await findByDate({ le: exact })).toHaveLength(1);
+      expect(await findByDate({ le: future })).toHaveLength(1);
+      expect(await findByDate({ le: past })).toHaveLength(0);
+    });
+
+    it("in", async () => {
+      expect(await findByDate({ in: [past, exact, future] })).toHaveLength(1);
+      expect(await findByDate({ in: [past, future] })).toHaveLength(0);
+    });
+
+    it("notIn", async () => {
+      expect(await findByDate({ notIn: [past, future] })).toHaveLength(1);
+      expect(await findByDate({ notIn: [past, exact, future] })).toHaveLength(
+        0,
+      );
+    });
+
+    it("between", async () => {
+      expect(await findByDate({ between: [past, future] })).toHaveLength(1);
+      expect(await findByDate({ between: [exact, exact] })).toHaveLength(1);
+      expect(await findByDate({ between: [future, future] })).toHaveLength(0);
+    });
+
+    it("notBetween", async () => {
+      expect(await findByDate({ notBetween: [future, future] })).toHaveLength(
+        1,
+      );
+      expect(await findByDate({ notBetween: [past, future] })).toHaveLength(0);
+    });
+  });
+});

--- a/src/test/parser-query.test.ts
+++ b/src/test/parser-query.test.ts
@@ -416,7 +416,7 @@ describe("query parser tests", async () => {
         "self.addresses": "self_addresses",
       },
       where:
-        "jsonb_path_exists(self.attrs, '$.name ? (@ == $p0)', jsonb_build_object('p0', cast(:p0 as text))) AND jsonb_path_exists(self_bio.me, '$.some ? (@ == $p1 || @ == $p2 || @ == $p3)', jsonb_build_object('p1', cast(:p1 as integer), 'p2', cast(:p2 as integer), 'p3', cast(:p3 as integer))) AND jsonb_path_exists(self_addresses.props, '$.some ? (@ >= $p4 && @ <= $p5)', jsonb_build_object('p4', cast(:p4 as timestamp), 'p5', cast(:p5 as timestamp)))",
+        "jsonb_path_exists(self.attrs, '$.name ? (@ == $p0)', jsonb_build_object('p0', cast(:p0 as text))) AND jsonb_path_exists(self_bio.me, '$.some ? (@ == $p1 || @ == $p2 || @ == $p3)', jsonb_build_object('p1', cast(:p1 as integer), 'p2', cast(:p2 as integer), 'p3', cast(:p3 as integer))) AND jsonb_path_exists(self_addresses.props, '$.some ? (@.datetime() >= $p4.datetime() && @.datetime() <= $p5.datetime())', jsonb_build_object('p4', cast(:p4 as timestamp), 'p5', cast(:p5 as timestamp)))",
       params: {
         p0: "some",
         p1: 1,


### PR DESCRIPTION
### Symmetric casting for JSON path parameters
PostgreSQL's jsonpath engine requires both sides of a comparison to be the same type. Previously only the field placeholder (`@`) was cast to `.double()` or `.datetime()` — the parameter variable (e.g. `$p0`) was left uncast, causing strict type-mismatch errors at runtime. Both sides are now cast symmetrically.

### Global regex for `@` replacement
The `@` placeholder replacement used a non-global regex, so only the first occurrence was cast. This broke `between` and `in` operators which generate multiple `@` references in a single condition. Replaced with `/g` flag to cast all occurrences.

### Safer type inference in `findJsonType`
`findJsonType` ran regex tests directly on the value without checking its type first. Passing `null`, `undefined`, or a non-string (e.g. a `Date` object or `boolean`) would either throw or produce the wrong inferred type. Added null/undefined guards and wrapped the regex checks inside a `typeof value === "string"` guard.

### Test cases to demonstrate the issue
Added test cases that would fail without these fixes