### PR TITLE
Fix schema lookups and repository resolution to be resilient to mangling

### DIFF
--- a/src/client/parser/context.ts
+++ b/src/client/parser/context.ts
@@ -93,8 +93,10 @@ export class ParserContext {
 
   isStringField(repo: Repository<any>, name: string): boolean {
     if (!this.schema) return false;
+    const ns = repo.metadata.connection.namingStrategy;
     const schemaDef = this.schema.find(
-      (x) => x.table === repo.metadata.tableName,
+      (x) =>
+        ns.tableName(x.name, x.table) === repo.metadata.tableNameWithoutPrefix,
     );
     const fieldDef = schemaDef?.fields?.find((x) => x.name === name);
     return fieldDef?.type === "String";

--- a/src/client/parser/context.ts
+++ b/src/client/parser/context.ts
@@ -94,7 +94,7 @@ export class ParserContext {
   isStringField(repo: Repository<any>, name: string): boolean {
     if (!this.schema) return false;
     const schemaDef = this.schema.find(
-      (x) => x.name === repo.metadata.targetName,
+      (x) => x.table === repo.metadata.tableName,
     );
     const fieldDef = schemaDef?.fields?.find((x) => x.name === name);
     return fieldDef?.type === "String";

--- a/src/client/repository/query/query.ts
+++ b/src/client/repository/query/query.ts
@@ -94,7 +94,7 @@ const doQuery = async (
       );
     }
 
-    const rr = repo.manager.getRepository(relation.inverseEntityMetadata.name);
+    const rr = repo.manager.getRepository(relation.inverseEntityMetadata.target);
     const nq = relationQuery(repo.manager, relation)
       .clone()
       .setParameter("__parents", ids);

--- a/src/client/repository/repository.test.ts
+++ b/src/client/repository/repository.test.ts
@@ -7,7 +7,17 @@ describe("EntityRepository protected field guards", () => {
     ({
       metadata: {
         name: "Thing",
+        tableName: "thing",
+        tableNameWithoutPrefix: "thing",
         findRelationWithPropertyPath: () => null,
+        connection: {
+          namingStrategy: {
+            tableName: (
+              targetName: string,
+              userSpecifiedName: string | undefined,
+            ) => userSpecifiedName ?? targetName.toLowerCase(),
+          },
+        },
       },
       create: vi.fn(),
       save: vi.fn(),
@@ -19,6 +29,7 @@ describe("EntityRepository protected field guards", () => {
       __schema: [
         {
           name: "Thing",
+          table: "thing",
           fields: [
             { name: "secret", type: "String", internal: true },
             { name: "auditStamp", type: "DateTime", readonly: true },

--- a/src/client/repository/repository.ts
+++ b/src/client/repository/repository.ts
@@ -35,12 +35,16 @@ import { isValueSame, valueOrID } from "./utils";
 import { getSimpleSelect } from "../parser/processors/select-processor";
 
 function getProtectedFields(
+  repo: OrmRepository<any>,
   client: QueryClient,
-  entityTable: string,
   mode: "create" | "update",
 ): Set<string> {
+  const ns = repo.metadata.connection.namingStrategy;
   const schema: EntityOptions[] = (client as any).__schema ?? [];
-  const entity = schema.find((e) => e.table === entityTable);
+  const entity = schema.find(
+    (e) =>
+      ns.tableName(e.name, e.table) === repo.metadata.tableNameWithoutPrefix,
+  );
   if (!entity?.fields) return new Set();
   return new Set(
     entity.fields
@@ -287,7 +291,7 @@ export class EntityRepository<T extends Entity> implements Repository<T> {
     meta: EntityMetadata,
     data: CreateArgs<T>,
   ) {
-    const protectedFields = getProtectedFields(this.#client, meta.tableName, "create");
+    const protectedFields = getProtectedFields(repo, this.#client, "create");
     rejectProtectedFields(Object.keys(data), protectedFields, meta.name);
 
     const attrs: Record<string, any> = {};
@@ -429,7 +433,7 @@ export class EntityRepository<T extends Entity> implements Repository<T> {
     const { id, version, ...rest } = data;
 
     const meta = repo.metadata;
-    const protectedFields = getProtectedFields(this.#client, meta.tableName, "update");
+    const protectedFields = getProtectedFields(repo, this.#client, "update");
     rejectProtectedFields(Object.keys(rest), protectedFields, meta.name);
 
     const attrs: Record<string, any> = {};

--- a/src/client/repository/repository.ts
+++ b/src/client/repository/repository.ts
@@ -36,11 +36,11 @@ import { getSimpleSelect } from "../parser/processors/select-processor";
 
 function getProtectedFields(
   client: QueryClient,
-  entityName: string,
+  entityTable: string,
   mode: "create" | "update",
 ): Set<string> {
   const schema: EntityOptions[] = (client as any).__schema ?? [];
-  const entity = schema.find((e) => e.name === entityName);
+  const entity = schema.find((e) => e.table === entityTable);
   if (!entity?.fields) return new Set();
   return new Set(
     entity.fields
@@ -81,7 +81,7 @@ class RelationHandlers {
     const update = Array.isArray(data.update) ? data.update[0] : data.update;
 
     const rMeta = relation.inverseEntityMetadata;
-    const rRepo = repo.manager.getRepository(rMeta.name);
+    const rRepo = repo.manager.getRepository(rMeta.target);
 
     // Import EntityRepository here to avoid circular dependency
     const { EntityRepository } = await import("./repository");
@@ -124,7 +124,7 @@ class RelationHandlers {
     const field = relation.propertyName;
     const inverseField = relation.inverseRelation?.propertyName;
     const rMeta = relation.inverseEntityMetadata;
-    const rRepo = repo.manager.getRepository(rMeta.name);
+    const rRepo = repo.manager.getRepository(rMeta.target);
 
     const link = inverseField
       ? { [inverseField]: { select: { id: obj.id } } }
@@ -287,7 +287,7 @@ export class EntityRepository<T extends Entity> implements Repository<T> {
     meta: EntityMetadata,
     data: CreateArgs<T>,
   ) {
-    const protectedFields = getProtectedFields(this.#client, meta.name, "create");
+    const protectedFields = getProtectedFields(this.#client, meta.tableName, "create");
     rejectProtectedFields(Object.keys(data), protectedFields, meta.name);
 
     const attrs: Record<string, any> = {};
@@ -429,7 +429,7 @@ export class EntityRepository<T extends Entity> implements Repository<T> {
     const { id, version, ...rest } = data;
 
     const meta = repo.metadata;
-    const protectedFields = getProtectedFields(this.#client, meta.name, "update");
+    const protectedFields = getProtectedFields(this.#client, meta.tableName, "update");
     rejectProtectedFields(Object.keys(rest), protectedFields, meta.name);
 
     const attrs: Record<string, any> = {};

--- a/src/test/mangling-resilience.test.ts
+++ b/src/test/mangling-resilience.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createClient, type GooveeClient } from "./db/client";
+import { Address, Bio, Contact, Title } from "./db/models";
+
+// Bundlers (webpack, turbopack) mangle top-level class identifiers in
+// production builds, which changes Function.name at runtime. TypeORM captures
+// EntityMetadata.targetName / .name from `(EntityClass as Function).name` once
+// during DataSource.initialize(); any code that later compares those names to
+// values baked at compile time silently mismatches.
+//
+// These tests reproduce that scenario by mutating Function.name on specific
+// entity classes immediately before initializing a fresh DataSource, then
+// restoring the originals so unrelated tests run later see entities under their
+// real identity.
+
+type Cls = { name: string };
+
+const define = (klass: Cls, value: string) => {
+  Object.defineProperty(klass, "name", { value, configurable: true });
+};
+
+describe("mangling resilience for entity schema lookups", () => {
+  let client: GooveeClient;
+  const original = {
+    Contact: Contact.name,
+    Title: Title.name,
+    Address: Address.name,
+    Bio: Bio.name,
+  };
+
+  const restoreAll = () => {
+    define(Contact, original.Contact);
+    define(Title, original.Title);
+    define(Address, original.Address);
+    define(Bio, original.Bio);
+  };
+
+  afterEach(async () => {
+    restoreAll();
+    if (client?.$connected) await client.$disconnect();
+  });
+
+  const connectWith = async (
+    mangle: () => void,
+    features: Parameters<typeof createClient>[0]["features"] = {},
+  ) => {
+    mangle();
+    client = createClient({ features });
+    await client.$connect();
+    // metadata is now cached; restore the real Function.name so any code that
+    // reads it later (e.g. other test files) sees the original identity.
+    restoreAll();
+    await client.$sync(true);
+  };
+
+  describe("isStringField (parser/context.ts)", () => {
+    beforeEach(async () => {
+      await connectWith(() => define(Contact, "a"), {
+        normalization: { lowerCase: true, unaccent: true },
+      });
+      await client.$raw("CREATE EXTENSION IF NOT EXISTS unaccent");
+    });
+
+    it("applies unaccent normalization when entity class name is mangled", async () => {
+      await client.contact.create({
+        data: { firstName: "José", lastName: "González" },
+      });
+
+      const results = await client.contact.find({
+        select: { firstName: true },
+        where: { firstName: "Jose" },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].firstName).toBe("José");
+    });
+
+    it("applies lowerCase normalization when entity class name is mangled", async () => {
+      await client.contact.create({
+        data: { firstName: "John", lastName: "Smith" },
+      });
+
+      const results = await client.contact.find({
+        select: { firstName: true },
+        where: { firstName: "john" },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].firstName).toBe("John");
+    });
+  });
+
+  describe("relation handling under mangling", () => {
+    it("ManyToOne reference resolves the inverse entity repo when inverse class is mangled", async () => {
+      // Title is the inverse side of Contact.title — mangle it.
+      await connectWith(() => define(Title, "b"));
+
+      const { id: titleId } = await client.title.create({
+        data: { code: "MR", name: "Mr." },
+      });
+
+      // This exercises RelationHandlers.handleReference, which calls
+      // repo.manager.getRepository(rMeta.name) on the unfixed code.
+      const created = await client.contact.create({
+        data: {
+          firstName: "John",
+          lastName: "Doe",
+          title: { select: { id: titleId } },
+        },
+        select: { id: true, title: { id: true, name: true } },
+      });
+
+      expect(created.title?.name).toBe("Mr.");
+    });
+
+    it("OneToMany collection-create resolves the inverse entity repo when inverse class is mangled", async () => {
+      // Address is the inverse side of Contact.addresses — mangle it.
+      await connectWith(() => define(Address, "c"));
+
+      // RelationHandlers.handleCollection → getRepository(rMeta.name) on unfixed.
+      const created = await client.contact.create({
+        data: {
+          firstName: "Jane",
+          lastName: "Doe",
+          addresses: {
+            create: [{ street: "1 Main St", city: "Springfield" }],
+          },
+        },
+        select: {
+          id: true,
+          addresses: { select: { id: true, street: true, city: true } },
+        },
+      });
+
+      expect(created.addresses).toHaveLength(1);
+      expect(created.addresses?.[0].street).toBe("1 Main St");
+    });
+
+    it("relation query loads collection when inverse class is mangled", async () => {
+      // doQuery in query.ts also reads relation.inverseEntityMetadata.name.
+      await connectWith(() => define(Address, "d"));
+
+      const { id } = await client.contact.create({
+        data: {
+          firstName: "Q",
+          lastName: "User",
+          addresses: { create: [{ street: "Elm", city: "Town" }] },
+        },
+      });
+
+      const found = await client.contact.findOne({
+        where: { id },
+        select: {
+          id: true,
+          addresses: { select: { id: true, street: true } },
+        },
+      });
+
+      expect(found?.addresses).toHaveLength(1);
+      expect(found?.addresses?.[0].street).toBe("Elm");
+    });
+  });
+
+  describe("relation reference resolved by String field under mangling", () => {
+    it("normalization applies on inverse entity's String field when inverse class is mangled", async () => {
+      // Mangle Title (the inverse side) so its metadata.targetName is "n".
+      // Then look up a Title by its String `name` with normalization features
+      // enabled — this exercises the inverse-side parser's isStringField path.
+      await connectWith(
+        () => define(Title, "n"),
+        { normalization: { lowerCase: true, unaccent: true } },
+      );
+      await client.$raw("CREATE EXTENSION IF NOT EXISTS unaccent");
+
+      await client.title.create({ data: { code: "MS", name: "José" } });
+
+      const created = await client.contact.create({
+        data: {
+          firstName: "Z",
+          lastName: "User",
+          title: { select: { name: "Jose" } }, // unaccented search on Title.name
+        },
+        select: { id: true, title: { id: true, name: true } },
+      });
+
+      expect(created.title?.name).toBe("José");
+    });
+  });
+
+  // The PR 18 description argues `getRepository(rMeta.name)` "works
+  // incidentally" because both sides use the mangled value. This test checks
+  // that argument by forcing a *collision* — two different entity classes
+  // mangled to the same Function.name. On unfixed code, getRepository(string)
+  // can then return the wrong entity's repository; on PR 18, getRepository
+  // receives the constructor reference (rMeta.target) and stays correct.
+  describe("relation handling under name collision", () => {
+    it("ManyToOne reference still picks the right inverse repo when two entity classes mangle to the same name", async () => {
+      await connectWith(() => {
+        define(Title, "x");
+        define(Bio, "x");
+      });
+
+      const { id: titleId } = await client.title.create({
+        data: { code: "DR", name: "Dr." },
+      });
+
+      const created = await client.contact.create({
+        data: {
+          firstName: "C",
+          lastName: "User",
+          title: { select: { id: titleId } },
+        },
+        select: { id: true, title: { id: true, name: true } },
+      });
+
+      expect(created.title?.name).toBe("Dr.");
+    });
+  });
+});


### PR DESCRIPTION
JavaScript bundlers (webpack, turbopack) mangle class and function names in production builds to reduce bundle size:

```js
// Source
class AOSPartner extends AuditableModel { ... }

// After mangling
class e extends t { ... }
```

This is harmless for most code, but breaks any code that **reads a class name at runtime** and compares it against a string baked in at compile time. Goovee ORM has several such patterns.

TypeORM's `EntityMetadata` exposes two relevant properties:

- `metadata.name` / `metadata.targetName` — the class constructor name (`(EntityClass as Function).name`). **Gets mangled.**
- `metadata.tableNameWithoutPrefix` — the table name after applying the naming strategy, before any global `entityPrefix`. **Never mangled** and stable for schema lookups regardless of DataSource prefix configuration.

Similarly, `RelationMetadata` exposes `.name` (the class constructor name, mangled) and `.target` (the class constructor reference, unaffected by mangling).

---

## Changes

### 1. `src/client/parser/context.ts` — `isStringField` schema lookup

`isStringField` is called during query parsing to decide whether to wrap a field in `lower()` / `unaccent()` for case-insensitive and accent-insensitive search. It looks up the entity's schema definition to check if a field is of type `String`.

The lookup was using `metadata.targetName` (mangled) to find the matching entry in `schemaDefs` (which stores original names like `"AOSPartner"`). This silently failed in production, causing `isStringField` to always return `false` and **disabling normalization entirely**.

The fix resolves the schema entry using the active TypeORM naming strategy — the same logic TypeORM uses to derive the table name from `@Entity()` decorator arguments — so the lookup is both mangling-resilient and correct regardless of which naming strategy is configured.

```ts
// Before
const schemaDef = this.schema.find((x) => x.name === repo.metadata.targetName);

// After
const ns = repo.metadata.connection.namingStrategy;
const schemaDef = this.schema.find(
  (x) => ns.tableName(x.name, x.table) === repo.metadata.tableNameWithoutPrefix,
);
```

### 2. `src/client/repository/repository.ts` — `getProtectedFields` schema lookup

`getProtectedFields` enforces that fields marked `internal` (never writable) or `readonly` (not updatable after creation) are rejected on create and update operations. It also looks up `schemaDefs` by entity name.

The lookup used `meta.name` (mangled), so the entity was never found. `getProtectedFields` would return an empty set, **silently bypassing all protected field checks**.

The fix passes the `repo` directly so `getProtectedFields` can use the naming strategy from the live connection, matching entries the same way TypeORM resolves them.

```ts
// Before
function getProtectedFields(client, entityName, mode) {
  const entity = schema.find((e) => e.name === entityName);
  ...
}
getProtectedFields(this.#client, meta.name, "create");
getProtectedFields(this.#client, meta.name, "update");

// After
function getProtectedFields(repo, client, mode) {
  const ns = repo.metadata.connection.namingStrategy;
  const entity = schema.find(
    (e) => ns.tableName(e.name, e.table) === repo.metadata.tableNameWithoutPrefix,
  );
  ...
}
getProtectedFields(repo, this.#client, "create");
getProtectedFields(repo, this.#client, "update");
```

### 3. `src/client/repository/repository.ts` and `src/client/repository/query/query.ts` — string-based `getRepository` calls

Three call sites were passing a string (the class constructor name) to TypeORM's `getRepository`. Under mangling, this works incidentally — `rMeta.name` and the internally registered metadata name are both the same mangled value — but it is fragile. If two entity classes are ever assigned the same mangled name (possible across async chunks), `getRepository(string)` silently returns the wrong repository.

The fix uses the class constructor reference instead, consistent with the already-correct pattern in `join-handler.ts` (`getRepository(relation.type)`).

```ts
// Before — string lookup, fragile under mangling
// repository.ts
const rRepo = repo.manager.getRepository(rMeta.name);
// query.ts
const rr = repo.manager.getRepository(relation.inverseEntityMetadata.name);

// After — class reference, safe under mangling
// repository.ts
const rRepo = repo.manager.getRepository(rMeta.target);
// query.ts
const rr = repo.manager.getRepository(relation.inverseEntityMetadata.target);
```



---

## Notes

The `portal` project also adds `--no-mangling` to its `next build` command as a short-term mitigation while these fixes are released. That flag can be removed once this ORM version is consumed.
