### PR TITLE
Prevent self-referential imports in code generation

### DIFF
--- a/src/code-generator/CodeFile.ts
+++ b/src/code-generator/CodeFile.ts
@@ -45,7 +45,10 @@ export class CodeFile {
     const iw = new CodeWriter();
     const tw = new CodeWriter();
 
+    const selfName = path.basename(this.fileName, path.extname(this.fileName));
     for (const [module, names] of Object.entries(this.imports)) {
+      const moduleName = path.basename(module, path.extname(module));
+      if (module.startsWith("./") && moduleName === selfName) continue;
       iw.write(`import { ${[...names].join(", ")} } from "${module}";`);
       iw.write("\n");
     }


### PR DESCRIPTION
## Problem

Generated model files are importing themselves, which causes TypeScript errors:

```
goovee/.generated/models/AOSComment.ts(10,10): error TS2395: Individual declarations in merged declaration 'AOSComment' must be all exported or all local.
goovee/.generated/models/AOSComment.ts(10,10): error TS2440: Import declaration conflicts with local declaration of 'AOSComment'.
```

## Solution

Skip generating imports for the current file. The code generator now:

1. Extracts the current file's name (without extension)
2. Skips any imports with module path matching `./selfName`

This prevents self-referential imports while preserving all necessary external imports.
