### PR TITLE
Align CRUD type operations for consistent BigDecimal handling

### DIFF
--- a/src/client/types/crud.ts
+++ b/src/client/types/crud.ts
@@ -18,6 +18,10 @@ interface NestedCreateManyArg<T extends Entity> {
 
 type AllowNull<T> = T extends undefined ? T | null : T;
 
+type LeafArg<T> = T extends BigDecimal
+  ? AllowNull<string | number | bigint | T>
+  : AllowNull<T>;
+
 export type CreateArg<T> =
   T extends Array<infer P>
     ? P extends Entity
@@ -25,9 +29,7 @@ export type CreateArg<T> =
       : T
     : T extends Entity
       ? NestedCreateArg<T>
-      : T extends BigDecimal
-        ? AllowNull<string | number | bigint | T>
-        : AllowNull<T>;
+      : LeafArg<T>;
 
 export type CreateArgs<T extends Entity> = {
   [K in keyof T]: CreateArg<T[K]>;
@@ -58,9 +60,7 @@ export type UpdateArg<T> =
       : T
     : T extends Entity
       ? NestedUpdateArg<T>
-      : T extends BigDecimal
-        ? AllowNull<string | number | bigint | T>
-        : AllowNull<T>;
+      : LeafArg<T>;
 
 export type UpdateArgs<T extends Entity> = InputIdentity<T> & {
   [K in keyof T]?: UpdateArg<T[K]>;

--- a/src/client/types/crud.ts
+++ b/src/client/types/crud.ts
@@ -89,7 +89,7 @@ export type BulkSetArg<T> =
       : T
     : T extends Entity
       ? { id: ID | null }
-      : T;
+      : LeafArg<T>;
 
 export type BulkSetOptions<
   T extends Entity,

--- a/src/client/types/crud.ts
+++ b/src/client/types/crud.ts
@@ -58,7 +58,9 @@ export type UpdateArg<T> =
       : T
     : T extends Entity
       ? NestedUpdateArg<T>
-      : AllowNull<T>;
+      : T extends BigDecimal
+        ? AllowNull<string | number | bigint | T>
+        : AllowNull<T>;
 
 export type UpdateArgs<T extends Entity> = InputIdentity<T> & {
   [K in keyof T]?: UpdateArg<T[K]>;

--- a/src/test/client-bigdecimal.test.ts
+++ b/src/test/client-bigdecimal.test.ts
@@ -139,4 +139,69 @@ describe("client BigDecimal tests", async () => {
     expect(gtZeroResults.map((r) => r.code)).toContain("P1");
     expect(gtZeroResults.map((r) => r.code)).not.toContain("Z1");
   });
+
+  it("should accept string, number, bigint, and BigDecimal and null values in update for BigDecimal fields", async () => {
+    const country = await client.country.create({
+      data: {
+        code: "UP",
+        name: "Update Test",
+        population: "100.00",
+      },
+    });
+
+    // Update with string
+    let updated = await client.country.update({
+      data: {
+        id: country.id,
+        version: country.version,
+        population: "200.00",
+      },
+      select: { population: true },
+    });
+    expect(updated.population?.toString()).toBe("200.00");
+
+    // Update with number
+    updated = await client.country.update({
+      data: {
+        id: country.id,
+        version: updated.version,
+        population: 300.5,
+      },
+      select: { population: true },
+    });
+    expect(updated.population?.toString()).toBe("300.5");
+
+    // Update with bigint
+    updated = await client.country.update({
+      data: {
+        id: country.id,
+        version: updated.version,
+        population: 400n,
+      },
+      select: { population: true },
+    });
+    expect(updated.population?.toString()).toBe("400");
+
+    // Update with BigDecimal instance
+    updated = await client.country.update({
+      data: {
+        id: country.id,
+        version: updated.version,
+        population: new BigDecimal("500.25"),
+      },
+      select: { population: true },
+    });
+    expect(updated.population?.toString()).toBe("500.25");
+
+    // Update with null
+    updated = await client.country.update({
+      data: {
+        id: country.id,
+        version: updated.version,
+        population: null,
+      },
+      select: { population: true },
+    });
+    expect(updated.population).toBeNull();
+  });
 });

--- a/src/test/client-bulk.test.ts
+++ b/src/test/client-bulk.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BigDecimal } from "../client";
 import { getTestClient } from "./client.utils";
 import { createData } from "./fixture";
 
@@ -264,6 +265,77 @@ describe("client bulk operations tests", async () => {
 
     expect(result).toBeDefined();
     expect(result.length).toBe(0);
+  });
+
+  it("should bulk update with string, number, bigint, BigDecimal, and null values for BigDecimal fields", async () => {
+    await client.country.create({
+      data: { code: "BU", name: "Bulk Update Test", population: "100.00" },
+    });
+
+    // Bulk update with string
+    let updated = await client.country.updateAll({
+      set: { population: "200.50" },
+      where: { code: "BU" },
+    });
+    expect(updated).toBe(1);
+
+    let result = await client.country.findOne({
+      where: { code: "BU" },
+      select: { population: true },
+    });
+    expect(result?.population?.toString()).toBe("200.50");
+
+    // Bulk update with number
+    updated = await client.country.updateAll({
+      set: { population: 300.75 },
+      where: { code: "BU" },
+    });
+    expect(updated).toBe(1);
+
+    result = await client.country.findOne({
+      where: { code: "BU" },
+      select: { population: true },
+    });
+    expect(result?.population?.toString()).toBe("300.75");
+
+    // Bulk update with bigint
+    updated = await client.country.updateAll({
+      set: { population: 400n },
+      where: { code: "BU" },
+    });
+    expect(updated).toBe(1);
+
+    result = await client.country.findOne({
+      where: { code: "BU" },
+      select: { population: true },
+    });
+    expect(result?.population?.toString()).toBe("400");
+
+    // Bulk update with BigDecimal instance
+    updated = await client.country.updateAll({
+      set: { population: new BigDecimal("500.25") },
+      where: { code: "BU" },
+    });
+    expect(updated).toBe(1);
+
+    result = await client.country.findOne({
+      where: { code: "BU" },
+      select: { population: true },
+    });
+    expect(result?.population?.toString()).toBe("500.25");
+
+    // Bulk update with null
+    updated = await client.country.updateAll({
+      set: { population: null },
+      where: { code: "BU" },
+    });
+    expect(updated).toBe(1);
+
+    result = await client.country.findOne({
+      where: { code: "BU" },
+      select: { population: true },
+    });
+    expect(result?.population).toBeNull();
   });
 
   it("should auto-set timestamps on bulk create", async () => {


### PR DESCRIPTION
# Align CRUD type operations for consistent BigDecimal handling

## Problem

The ORM CRUD types had inconsistent handling of BigDecimal fields:

```typescript
// ✅ Works - string accepted
await client.country.create({ data: { population: "138.50" } });
await client.country.find({ where: { population: { gt: "15.00" } } });

// ❌ Type error - string rejected
await client.country.update({
  data: { id: 1, version: 1, population: "138.50" }
});

// ❌ Type error - string rejected in bulk
await client.country.updateAll({
  set: { population: "138.50" }
});
```

## Solution

### 1. Extract Shared Type (structural symmetry)
Created `LeafArg<T>` type to eliminate copy-paste logic and prevent future drift:
- Handles BigDecimal special-casing: accepts `string | number | bigint | BigDecimal`
- Applies `AllowNull` for nullable fields
- Used consistently across `CreateArg`, `UpdateArg`, and `BulkSetArg`

### 2. Extend to Bulk Operations
Updated `BulkSetArg<T>` to use `LeafArg<T>`, bringing parity with standard update operations

### 3. Comprehensive Test Coverage
- Update operations: test all supported types (string, number, bigint, BigDecimal instance, null)
- Bulk operations: mirror the update test pattern with chained operations
- Ensures the type contract is locked and prevents regressions

## Changes

- `src/client/types/crud.ts`: Extract `LeafArg<T>`, apply to `CreateArg`, `UpdateArg`, `BulkSetArg`
- `src/test/client-bigdecimal.test.ts`: Comprehensive update test covering all value types
- `src/test/client-bulk.test.ts`: Bulk operation test mirroring update test pattern