### PR TITLE
Upgrade GitHub Actions, refactor CI setup, align Node engines

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,14 @@
+name: 'Setup'
+description: 'Setup pnpm, Node.js, and install dependencies'
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: "22.x"
+        registry-url: "https://registry.npmjs.org"
+        cache: "pnpm"
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,15 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v3
-        with:
-          version: latest
-      - run: pnpm install
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
       - name: Build
         run: pnpm build
 
@@ -29,15 +22,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v3
-        with:
-          version: latest
-      - run: pnpm install
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
       - name: Run Tests
         run: pnpm test
 
@@ -49,16 +35,9 @@ jobs:
         image: docker:dind
         options: --privileged
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v3
-        with:
-          version: latest
-      - run: pnpm install
-      - uses: docker/setup-docker-action@v4
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - uses: docker/setup-docker-action@v5
       - name: Run E2E Tests
         run: pnpm test:e2e
 
@@ -68,17 +47,10 @@ jobs:
     name: Publish next release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v3
-        with:
-          version: latest
-      - run: pnpm install
+      - uses: ./.github/actions/setup
       - name: Set next version with timestamp and commit SHA
         run: |
           BASE_VERSION=$(node -p "require('./package.json').version")
@@ -99,27 +71,21 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     name: Release tag
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
-      - name: Create GitHub release
-        id: create-new-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v3
-        with:
-          version: latest
-      - run: pnpm install
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
       - name: Build
         run: pnpm build
       - name: Publish packages with latest tag
         run: pnpm release --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vitest": "^4.0.2"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=22.11.0"
   },
   "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8"
 }


### PR DESCRIPTION
## Summary

Upgrade all GitHub Actions to their latest majors, deduplicate the pnpm/Node setup into a composite action, replace a deprecated action, and align `engines.node` with what CI actually exercises.

## Changes

### Action upgrades
- `actions/checkout`: v3 → v6
- `actions/setup-node`: v3 → v6 (Node 18 → 22.x)
- `pnpm/action-setup`: v3 → v6 (drops `version: latest`; reads pnpm version from `packageManager` in `package.json`)
- `docker/setup-docker-action`: v4 → v5
- `actions/create-release@v1` (archived/deprecated) → `softprops/action-gh-release@v3`

### Workflow refactor
- Extract repeated pnpm + Node + install steps into `.github/actions/setup` composite action. Avoids the partial-upgrade asymmetry flagged in earlier review and removes 4× duplication.
- Add `permissions: contents: write` on the release job (required by `softprops/action-gh-release`).

### Engines
- Bump `engines.node` from `>=18.18.0` to `>=22.11.0` so the declared minimum matches CI. `22.11.0` is the first LTS release of the v22 line.

## Test plan

- [x] `build`, `test`, `test-e2e` jobs green on this PR
- [ ] Verify `publish-next` runs cleanly on merge to `dev`
- [ ] Verify `publish` runs cleanly on next tag push (release creation now via `softprops/action-gh-release`)