### PR TITLE
Add explicit NULL ordering and NULL-aware cursor pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,21 @@ const addresses = await client.address.find({
     },
   },
 });
+
+// Control NULL placement explicitly
+const contacts = await client.contact.find({
+  orderBy: {
+    lastName: "ASC_NULLS_LAST",
+    firstName: "DESC_NULLS_FIRST",
+  },
+});
 ```
+
+Supported values: `"ASC"`, `"DESC"`, `"ASC_NULLS_FIRST"`, `"ASC_NULLS_LAST"`,
+`"DESC_NULLS_FIRST"`, `"DESC_NULLS_LAST"`. Plain `"ASC"`/`"DESC"` use the
+database default (PostgreSQL: `ASC` → NULLS LAST, `DESC` → NULLS FIRST); use
+the explicit variants when you need to pin NULL placement independently of
+sort direction.
 
 #### Pagination
 

--- a/src/client/parser/cursor.ts
+++ b/src/client/parser/cursor.ts
@@ -58,9 +58,10 @@ export function parseCursor(
     return {};
   }
 
+  const invert = (take ?? 0) < 0;
   let count = 0;
 
-  const makeWhere = (items: CursorTuple[], invert: boolean): WhereResult => {
+  const makeWhere = (items: CursorTuple[]): WhereResult => {
     const [first, ...rest] = items;
     const [key, order, value] = first;
 
@@ -71,21 +72,47 @@ export function parseCursor(
     params[p] = value;
 
     const op = invert ? ORDER_OPS_INVERTED[order] : ORDER_OPS[order];
+    const isAsc = order.startsWith("ASC");
+    const nullsFirst = order.includes("NULLS_FIRST");
+    const nullsLast = order.includes("NULLS_LAST");
+
+    // Forward direction: where do NULLs sit?
+    // Explicit NULLS_FIRST/LAST wins; otherwise fall back to the DB
+    // (Postgres) default: ASC -> NULLS LAST, DESC -> NULLS FIRST.
+    let effectiveNullsFirst: boolean;
+    if (nullsFirst) effectiveNullsFirst = true;
+    else if (nullsLast) effectiveNullsFirst = false;
+    else effectiveNullsFirst = !isAsc;
+
+    if (invert) effectiveNullsFirst = !effectiveNullsFirst;
+
+    let comp: string;
+    if (value === null) {
+      // NULL at the start of our direction -> everything non-null is after it.
+      // NULL at the end -> nothing is after it.
+      comp = effectiveNullsFirst ? `${key} IS NOT NULL` : "FALSE";
+    } else if (!effectiveNullsFirst) {
+      // NULLs sit on the "after" side, so pull trailing NULL rows in too.
+      comp = `(${key} ${op} :${p} OR ${key} IS NULL)`;
+    } else {
+      comp = `${key} ${op} :${p}`;
+    }
+
+    const eq = `${key} IS NOT DISTINCT FROM :${p}`;
 
     if (rest && rest.length) {
-      const next = makeWhere(rest, invert);
+      const next = makeWhere(rest);
       if (rest.length > 1 && next.where) next.where = `(${next.where})`;
-      where = `${key} ${op} :${p} OR (${key} = :${p} AND ${next.where})`;
+      where = `${comp} OR (${eq} AND ${next.where})`;
       params = { ...params, ...next.params };
     } else {
-      where = `${key} ${op} :${p}`;
+      where = comp;
     }
 
     return { where, params, joins: {} };
   };
 
-  const invert = (take ?? 0) < 0;
-  const { where, params } = makeWhere(cur, invert);
+  const { where, params } = makeWhere(cur);
 
   if (invert) {
     const order = Object.entries(orderBy).reduce(

--- a/src/client/parser/types.ts
+++ b/src/client/parser/types.ts
@@ -73,16 +73,28 @@ export const JSON_CAST_TYPES = {
 export const ORDER_OPS = {
   ASC: ">",
   DESC: "<",
+  ASC_NULLS_FIRST: ">",
+  ASC_NULLS_LAST: ">",
+  DESC_NULLS_FIRST: "<",
+  DESC_NULLS_LAST: "<",
 } as const;
 
 export const ORDER_OPS_INVERTED = {
   ASC: "<",
   DESC: ">",
+  ASC_NULLS_FIRST: "<",
+  ASC_NULLS_LAST: "<",
+  DESC_NULLS_FIRST: ">",
+  DESC_NULLS_LAST: ">",
 } as const;
 
 export const ORDER_INVERTED = {
   ASC: "DESC",
   DESC: "ASC",
+  ASC_NULLS_FIRST: "DESC_NULLS_LAST",
+  ASC_NULLS_LAST: "DESC_NULLS_FIRST",
+  DESC_NULLS_FIRST: "ASC_NULLS_LAST",
+  DESC_NULLS_LAST: "ASC_NULLS_FIRST",
 } as const;
 
 export const ID_SELECT: Record<string, string> = {

--- a/src/client/repository/query/query.ts
+++ b/src/client/repository/query/query.ts
@@ -7,7 +7,7 @@ import {
   parseCursor,
 } from "../../parser";
 import { OrmRepository } from "../types";
-import { createSelectQuery, relationQuery } from "./utils";
+import { createSelectQuery, relationQuery, toSqlOrder } from "./utils";
 
 export const runQuery = async (
   repo: OrmRepository<any>,
@@ -66,7 +66,7 @@ const doQuery = async (
       // when fetching previous page with a cursor we have to invert
       // the original ordering first to get required data and finally
       // return the result with the requested order.
-      const sub = new SelectQueryBuilder(sq).orderBy(cur.order);
+      const sub = new SelectQueryBuilder(sq).orderBy(toSqlOrder(cur.order));
       const res = await sub.getMany();
       const ids = res.map((x) => x.id);
       if (ids.length === 0) return noResult;

--- a/src/client/repository/query/utils.ts
+++ b/src/client/repository/query/utils.ts
@@ -1,8 +1,25 @@
-import { EntityManager, QueryBuilder } from "typeorm";
+import { EntityManager, OrderByCondition, QueryBuilder } from "typeorm";
 import { RelationMetadata } from "typeorm/metadata/RelationMetadata.js";
 import { parseQuery, ParseResult } from "../../parser";
 import type { Entity, QueryClient, WhereOptions } from "../../types";
 import { OrmRepository } from "../types";
+
+type OrderByValue = OrderByCondition[string];
+
+const SQL_ORDER: Record<string, OrderByValue> = {
+  ASC: "ASC",
+  DESC: "DESC",
+  ASC_NULLS_FIRST: { order: "ASC", nulls: "NULLS FIRST" },
+  ASC_NULLS_LAST: { order: "ASC", nulls: "NULLS LAST" },
+  DESC_NULLS_FIRST: { order: "DESC", nulls: "NULLS FIRST" },
+  DESC_NULLS_LAST: { order: "DESC", nulls: "NULLS LAST" },
+};
+
+export const toSqlOrder = (order: Record<string, string>): OrderByCondition =>
+  Object.entries(order).reduce(
+    (prev, [k, v]) => ({ ...prev, [k]: SQL_ORDER[v] }),
+    {} as OrderByCondition,
+  );
 
 export const relationQuery = (
   manager: EntityManager,
@@ -122,7 +139,7 @@ export const createSelectQuery = <T extends Entity>(
   }
 
   if (where) sq.andWhere(where, params);
-  if (order) sq.orderBy(order);
+  if (order) sq.orderBy(toSqlOrder(order));
 
   return sq;
 };

--- a/src/client/types/base.ts
+++ b/src/client/types/base.ts
@@ -60,4 +60,10 @@ export type Options<T, U> = {
   [K in keyof T]: K extends keyof U ? T[K] : never;
 };
 
-export type OrderBy = "ASC" | "DESC";
+export type OrderBy =
+  | "ASC"
+  | "DESC"
+  | "ASC_NULLS_FIRST"
+  | "ASC_NULLS_LAST"
+  | "DESC_NULLS_FIRST"
+  | "DESC_NULLS_LAST";

--- a/src/graphql/graphql-schema.test.ts
+++ b/src/graphql/graphql-schema.test.ts
@@ -69,4 +69,21 @@ describe("GraphQL schema tests", async () => {
     const schema = buildGraphQLSchema([user]);
     expect(schema.getType("UserType")).toBeDefined();
   });
+
+  it("should have NULLS FIRST/LAST in OrderBy enum", async () => {
+    const user = defineEntity({
+      name: "User",
+      fields: [{ name: "name", type: "String" }],
+    });
+    const schema = buildGraphQLSchema([user]);
+    const orderBy = schema.getType("OrderBy") as any;
+    expect(orderBy).toBeDefined();
+    const values = orderBy.getValues().map((x: any) => x.name);
+    expect(values).toContain("ASC");
+    expect(values).toContain("DESC");
+    expect(values).toContain("ASC_NULLS_FIRST");
+    expect(values).toContain("ASC_NULLS_LAST");
+    expect(values).toContain("DESC_NULLS_FIRST");
+    expect(values).toContain("DESC_NULLS_LAST");
+  });
 });

--- a/src/graphql/graphql-schema.ts
+++ b/src/graphql/graphql-schema.ts
@@ -117,6 +117,10 @@ const OrderBy = new GraphQLEnumType({
   values: {
     ASC: { value: "ASC" },
     DESC: { value: "DESC" },
+    ASC_NULLS_FIRST: { value: "ASC_NULLS_FIRST" },
+    ASC_NULLS_LAST: { value: "ASC_NULLS_LAST" },
+    DESC_NULLS_FIRST: { value: "DESC_NULLS_FIRST" },
+    DESC_NULLS_LAST: { value: "DESC_NULLS_LAST" },
   },
 });
 

--- a/src/test/parser-query.test.ts
+++ b/src/test/parser-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseQuery } from "../client/parser";
+import { encodeCursor, parseCursor } from "../client/parser/cursor";
 import { QueryOptions } from "../client/types";
 import { getTestClient } from "./client.utils";
 
@@ -10,6 +11,131 @@ describe("query parser tests", async () => {
 
   // access the internal typeorm repo for testing
   const getContactRepo = () => (client.contact as any).unwrap();
+
+  it("should parse cursor with ASC_NULLS_LAST", () => {
+    const cursor = encodeCursor([["self.firstName", "ASC_NULLS_LAST", "John"]]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC_NULLS_LAST" },
+      cursor,
+    });
+    // ASC NULLS LAST: nulls sort after non-nulls, so the page after John
+    // must also include trailing NULL rows.
+    expect(res.where).toBe("(self.firstName > :q0 OR self.firstName IS NULL)");
+  });
+
+  it("should parse cursor with ASC_NULLS_FIRST", () => {
+    const cursor = encodeCursor([
+      ["self.firstName", "ASC_NULLS_FIRST", "John"],
+    ]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC_NULLS_FIRST" },
+      cursor,
+    });
+    // ASC NULLS FIRST: NULLs already passed, so just > John.
+    expect(res.where).toBe("self.firstName > :q0");
+  });
+
+  it("should parse cursor with DESC_NULLS_LAST and non-null value", () => {
+    const cursor = encodeCursor([
+      ["self.firstName", "DESC_NULLS_LAST", "John"],
+    ]);
+    const res = parseCursor({
+      order: { "self.firstName": "DESC_NULLS_LAST" },
+      cursor,
+    });
+    // DESC NULLS LAST: nulls sort after non-nulls, include trailing NULLs.
+    expect(res.where).toBe("(self.firstName < :q0 OR self.firstName IS NULL)");
+  });
+
+  it("should parse backward cursor with ASC_NULLS_LAST", () => {
+    const cursor = encodeCursor([["self.firstName", "ASC_NULLS_LAST", "John"]]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC_NULLS_LAST" },
+      cursor,
+      take: -10,
+    });
+    // Backward through ASC NULLS LAST: previous page is rows < John;
+    // trailing NULLs are already past us, so exclude them.
+    expect(res.where).toBe("self.firstName < :q0");
+  });
+
+  it("should parse backward cursor with ASC_NULLS_FIRST", () => {
+    const cursor = encodeCursor([
+      ["self.firstName", "ASC_NULLS_FIRST", "John"],
+    ]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC_NULLS_FIRST" },
+      cursor,
+      take: -10,
+    });
+    // Backward through ASC NULLS FIRST: previous page is rows < John,
+    // and leading NULLs (sorted before everything) must be included.
+    expect(res.where).toBe("(self.firstName < :q0 OR self.firstName IS NULL)");
+  });
+
+  it("should parse cursor with NULL value and DESC", () => {
+    const cursor = encodeCursor([["self.firstName", "DESC", null]]);
+    const res = parseCursor({
+      order: { "self.firstName": "DESC" },
+      cursor,
+    });
+    // DESC defaults to NULLS FIRST (Postgres), so after NULL there are
+    // still non-null rows to return.
+    expect(res.where).toBe("self.firstName IS NOT NULL");
+  });
+
+  it("should parse multi-key cursor where leading key is NULL", () => {
+    const cursor = encodeCursor([
+      ["self.firstName", "ASC", null],
+      ["self.lastName", "ASC", "Doe"],
+    ]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC", "self.lastName": "ASC" },
+      cursor,
+    });
+    // ASC defaults to NULLS LAST: leading NULL means we are in the
+    // trailing NULL block; the only rows "after" share NULL firstName and
+    // have lastName > 'Doe'. The tie-break must use IS NOT DISTINCT FROM
+    // so the NULL = NULL match holds.
+    expect(res.where).toBe(
+      "FALSE OR (self.firstName IS NOT DISTINCT FROM :q0 AND (self.lastName > :q1 OR self.lastName IS NULL))",
+    );
+  });
+
+  it("should parse cursor with NULL value and ASC (default NULLS LAST)", () => {
+    const cursor = encodeCursor([["self.firstName", "ASC", null]]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC" },
+      cursor,
+    });
+    // ASC defaults to NULLS LAST; NULL sits at the trailing edge, so no
+    // rows come after it.
+    expect(res.where).toBe("FALSE");
+  });
+
+  it("should parse backward cursor with NULL value and ASC (default NULLS LAST)", () => {
+    const cursor = encodeCursor([["self.firstName", "ASC", null]]);
+    const res = parseCursor({
+      order: { "self.firstName": "ASC" },
+      cursor,
+      take: -10,
+    });
+    // Backward through ASC NULLS LAST starting at a NULL cursor: the
+    // previous page is every non-null row (they all sort before NULL).
+    expect(res.where).toBe("self.firstName IS NOT NULL");
+  });
+
+  it("should parse backward cursor with NULL value and DESC (default NULLS FIRST)", () => {
+    const cursor = encodeCursor([["self.firstName", "DESC", null]]);
+    const res = parseCursor({
+      order: { "self.firstName": "DESC" },
+      cursor,
+      take: -10,
+    });
+    // Backward through DESC NULLS FIRST starting at a NULL cursor: NULLs
+    // sit at the leading edge, so nothing comes before them.
+    expect(res.where).toBe("FALSE");
+  });
 
   it("should parse simple `select` options", () => {
     const opts: QueryOptions<Contact> = {


### PR DESCRIPTION
SQL has two orthogonal concepts for ordering nullable columns: the **direction** (ASC/DESC) and the **NULL placement** (NULLS FIRST/LAST). Postgres applies a default — `ASC → NULLS LAST`, `DESC → NULLS FIRST` — but callers often need explicit control, e.g. "most recent first, items without a date at the bottom" (`DESC NULLS LAST`).

The `OrderBy` type previously exposed only `"ASC"` and `"DESC"`, so callers could not pin NULL placement independently of direction. This PR adds four explicit variants and plumbs them through the parser, the GraphQL schema, and TypeORM's `OrderByCondition`.

While extending the cursor-pagination code for the new variants, several pre-existing bugs surfaced in the *plain* `ASC`/`DESC` path. Cursor pagination over **nullable columns** was silently dropping or misordering rows; this PR fixes those too.

---

## Changes

### 1. Extend the `OrderBy` enum

`OrderBy` gains `ASC_NULLS_FIRST`, `ASC_NULLS_LAST`, `DESC_NULLS_FIRST`, `DESC_NULLS_LAST`. The companion `ORDER_OPS` / `ORDER_INVERTED` tables in `parser/types.ts` are extended so existing comparison and inversion logic works for the new values — including symmetric flipping of both direction and null position for backward pagination.

### 2. Translate to TypeORM's `OrderByCondition`

A new `toSqlOrder` helper in `repository/query/utils.ts` maps the enum string to TypeORM's `{ order, nulls }` shape. `createSelectQuery` and the backward-pagination subquery route through it so the generated SQL contains real `NULLS FIRST/LAST` clauses.

### 3. Surface the values in GraphQL

The `OrderBy` enum in `graphql-schema.ts` gains the four new values. Because every per-entity `OrderBy` input and `JsonOrderByValue.order` reuse this single enum, the new values become available on every orderable field automatically. The schema change is purely additive — existing `ASC`/`DESC` clients keep working.

### 4. NULL-aware cursor predicate (bug fix)

`parser/cursor.ts` is rewritten to be NULL-correct. Three pre-existing bugs are fixed:

- **Multi-key tie-break** used `=`, which is *unknown* for NULL = NULL → rows were silently dropped. Now uses `IS NOT DISTINCT FROM`.
- **Trailing-NULL rows** were never reached, because `key > :cursor` is unknown when the row's key is NULL. When NULLs sit on the "after" side of the current direction, the predicate now adds `OR key IS NULL`.
- **A NULL cursor value** produced an empty page. Now handled explicitly: `IS NOT NULL` when NULLs are at the start of our direction, `FALSE` when at the end.

NULL placement is derived from the enum (explicit `NULLS_FIRST`/`LAST` wins; otherwise the Postgres default), and flipped for backward pagination so previous-page boundaries are symmetric with forward.

### 5. Tests

- Feature tests for forward and backward cursors with each new enum value.
- Regression tests for the bugs above, using only plain `"ASC"` / `"DESC"` — these fail against the old code.
- GraphQL schema test asserts the four new values are present.

### 6. README

"Sorting and Ordering" section gains an example, the list of six supported values, and a one-liner about the default fallback.

---

## Notes

The new SQL syntax (`NULLS FIRST/LAST`, `IS NOT DISTINCT FROM`) is Postgres-specific. Goovee ORM targets Postgres, so this is fine.

The cursor bug was scoped to **nullable columns**. Cursors keyed on `id` (the most common case, as shown in the README) were unaffected, which is likely why the bug survived this long.