### PR TITLE
Prevent self-referential imports in code generation

### DIFF
--- a/src/code-generator/CodeFile.ts
+++ b/src/code-generator/CodeFile.ts
@@ -45,7 +45,10 @@ export class CodeFile {
     const iw = new CodeWriter();
     const tw = new CodeWriter();
 
+    const selfName = path.basename(this.fileName, path.extname(this.fileName));
     for (const [module, names] of Object.entries(this.imports)) {
+      const moduleName = path.basename(module, path.extname(module));
+      if (module.startsWith("./") && moduleName === selfName) continue;
       iw.write(`import { ${[...names].join(", ")} } from "${module}";`);
       iw.write("\n");
     }

--- a/src/schema/schema-generator.test.ts
+++ b/src/schema/schema-generator.test.ts
@@ -661,4 +661,37 @@ describe("schema generator tests", () => {
     expect(code).toMatch(/implements\s+Auditable\b/);
     expect(code).toMatch(/from "\.\/Auditable"/);
   });
+
+  it("should not emit self-imports for relations targeting the entity itself", () => {
+    const Category = defineEntity({
+      name: "Category",
+      fields: [
+        {
+          name: "name",
+          type: "String",
+          required: true,
+        },
+        {
+          name: "parent",
+          type: "ManyToOne",
+          target: "Category",
+        },
+        {
+          name: "children",
+          type: "OneToMany",
+          target: "Category",
+          mappedBy: "parent",
+        },
+      ],
+    });
+
+    generateSchema(outDir, { schema: [Category] });
+    const code = fs.readFileSync(path.join(outDir, "Category.ts"), {
+      encoding: "utf-8",
+    });
+
+    expect(code).not.toMatch(/from "\.\/Category"/);
+    expect(code).toMatch(/parent\?:\s*Relation<Category>/);
+    expect(code).toMatch(/children\?:\s*Relation<Category>\[\]/);
+  });
 });


### PR DESCRIPTION
Reopens the fix from #20 (closed as superseded, but the cases it covers are still broken on `dev`).

## What this fixes

Self-referential **relation imports**. A tree-shaped entity like:

```ts
defineEntity({
  name: "Category",
  fields: [
    { name: "parent",   type: "ManyToOne", target: "Category" },
    { name: "children", type: "OneToMany", target: "Category", mappedBy: "parent" },
  ],
});
```

…causes `RelationalField.actualType` (`src/schema/schema-generator.ts:232-236`) to register `import { Category } from "./Category"` in the generated `Category.ts`, producing:

```
TS2440: Import declaration conflicts with local declaration of 'Category'.
TS2395: Individual declarations in merged declaration 'Category' must be all exported or all local.
```

## Relationship to d2ce123

d2ce123 ("Drop self-referential extends/implements at the source") fixes a **different** layer — the `extends` / `implements` clauses in the class declaration. It does not touch relation imports, so this PR is complementary, not redundant.

## Approach

Filter self-referential imports at the `CodeFile` level — a single choke point that covers any generator that happens to emit `import { X } from "./X"` for the file currently being written. Cheap, local, and future-proof against new generators.

## Test

Added a regression test (`schema-generator.test.ts`) using a self-referencing `Category` entity with `parent: ManyToOne(target: "Category")` and `children: OneToMany(target: "Category", mappedBy: "parent")`. The test asserts:

- No `import { Category } from "./Category"` line in the generated file.
- The relation type still renders correctly as `Relation<Category>` and `Relation<Category>[]`.

The test fails on `dev` without this PR's `CodeFile` filter and passes with it.