### PR TITLE
Fix Options<> excess-property guard under TypeScript 6.0

### DIFF
--- a/src/client/types/base.ts
+++ b/src/client/types/base.ts
@@ -56,8 +56,17 @@ export type OmitByType<T, Type> = Pick<
   { [K in keyof T]-?: T[K] extends Type ? never : K }[keyof T]
 >;
 
+// TS 6.0 infers the exact argument shape (unknown keys included), so T[K]
+// checks a value against itself — excess keys pass. U[K] checks against the
+// declared shape instead. The phantom-key branch keeps T[K] referenced so
+// TypeScript still infers T and Payload<T,U> still narrows to selected fields.
+// https://github.com/microsoft/TypeScript/issues/63515
 export type Options<T, U> = {
-  [K in keyof T]: K extends keyof U ? T[K] : never;
+  [K in keyof T]: K extends keyof U
+    ? K extends "__use_T_so_it_is_inferred__"
+      ? T[K]
+      : U[K]
+    : never;
 };
 
 export type OrderBy = "ASC" | "DESC";


### PR DESCRIPTION
Under TypeScript 6.0, unknown keys nested inside where/select/orderBy/create are silently accepted: 6.0 preserves the exact argument shape when inferring generics (microsoft/TypeScript#63515), so the previous per-slot `T[K]` check compared the inferred value against itself. The `Options<>` guard now checks every key against the declared shape (`U[K]`) instead, with a phantom branch keeping `T` inferable so `Payload<T, U>` still narrows to the selected fields.

Functionally: typos like `contact.find({ where: { addresses: { bogus: 1 } } })` are compile errors again under 6.0, restoring 5.9 behavior at every nesting depth. No runtime change — the guard is a type-level wrapper on the repository method signatures.

Greens the nested excess-key cases in the type test suite (#27) once the TypeScript 6.0 upgrade (#28) is in.

---
**Series (merge order):** #27 type tests (red by design) → #28 TypeScript 6.0 upgrade → #29 `Options<>` guard fix → #30 mappedBy fix. The suite in #27 goes fully green once all four are merged.